### PR TITLE
Rebuild for libboost 1.90

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 libboost_devel:
-- '1.88'
+- '1.90'
 openssl:
 - '3.5'
 target_platform:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 libboost_devel:
-- '1.88'
+- '1.90'
 openssl:
 - '3.5'
 target_platform:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 libboost_devel:
-- '1.88'
+- '1.90'
 openssl:
 - '3.5'
 target_platform:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '19'
 libboost_devel:
-- '1.88'
+- '1.90'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 openssl:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '19'
 libboost_devel:
-- '1.88'
+- '1.90'
 macos_machine:
 - arm64-apple-darwin20.0.0
 openssl:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ build:
   error_overlinking: true
   ignore_run_exports:
     - gtest
-  number: 0
+  number: 1
   skip: true  # [win]
   run_exports:
     - {{ pin_subpackage("ldas-tools-framecpp", max_pin="x.x") }}


### PR DESCRIPTION
Manual regeneration of the libboost 1.88 → 1.90 migration PR for the current main (`ldas-tools-framecpp` 4.0.3).

The autotick bot's previous attempt (PR #56) targeted the 3.0.5 era and was closed as stale. Rather than wait for the bot to retry, this opens a fresh rebuild PR against 4.0.3 so the dependent feedstocks can unblock:

- conda-forge/ldas-tools-frameapi-feedstock#26 — needs framecpp 4.0.3 + libboost 1.90
- conda-forge/ldas-tools-framecpp-swig-feedstock#54 — needs framecpp 4.0.3 + libboost 1.90
- conda-forge/ldas-tools-diskcacheapi-feedstock#24 — same chain via al

Changes:
- bump `libboost_devel` in all 5 `.ci_support/*.yaml` from `1.88` to `1.90`
- bump `recipe/meta.yaml` build number 0 → 1

ldas-tools-al 2.8.1 is already built for libboost 1.90 on the channel, so the host-side solver should be satisfiable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)